### PR TITLE
Make sure events are not canceled

### DIFF
--- a/src/net/TheDgtl/Stargate/Stargate.java
+++ b/src/net/TheDgtl/Stargate/Stargate.java
@@ -719,6 +719,7 @@ public class Stargate extends JavaPlugin {
 		
 		@EventHandler
 		public void onPlayerMove(PlayerMoveEvent event) {
+			if (event.isCancelled()) return;
 			Player player = event.getPlayer();
 			Portal portal = Portal.getByEntrance(event.getTo());
 			
@@ -782,6 +783,7 @@ public class Stargate extends JavaPlugin {
 		
 		@EventHandler
 		public void onPlayerInteract(PlayerInteractEvent event) {
+			if (event.isCancelled()) return;
 			Player player = event.getPlayer();
 			Block block = event.getClickedBlock();
 			


### PR DESCRIPTION
I know region protection plugins will cancel a PlayerInteractEvent or PlayerMoveEvent if the player doesn't have the permissions do the specified actions, so we should check if the event was canceled before doing the plugin's logic.
